### PR TITLE
Java 9 improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ The `ike.cljj.function` namespace includes three main helpers for this:
 * `sam` - creating an anonymous SAM impl, as it were a Clojure function
 * `defsam` - defining a named SAM impl, as if it were a Clojure function
 
+**WARNING:** You may need type hints to avoid `IllegalAccessError` in Java 9+.
+
 ```clojure
 (defsam my-sam
   java.util.function.Predicate

--- a/src/main/clojure/ike/cljj/internal/invoke.clj
+++ b/src/main/clojure/ike/cljj/internal/invoke.clj
@@ -2,7 +2,8 @@
   "Wrapper API for the java.lang.invoke API. Primarily this was limited
   to the methods functions needed to support ike.cljj.function."
   (:import (java.lang.invoke MethodType MethodHandles MethodHandleProxies MethodHandles$Lookup MethodHandle)
-           (java.util List)))
+           (java.util List)
+           (clojure.lang RT)))
 
 (defn ^Class array-class
   "Gets the array class for the given class."
@@ -28,7 +29,7 @@
   [^MethodType handle]
   (.wrap handle))
 
-(def ^MethodHandles$Lookup lookup (MethodHandles/publicLookup))
+(def ^MethodHandles$Lookup lookup (.in (MethodHandles/publicLookup) RT))
 
 (defn ^MethodHandle static-handle
   "Looks up a static method handle.

--- a/src/test/clojure/ike/cljj/function_test.clj
+++ b/src/test/clojure/ike/cljj/function_test.clj
@@ -4,33 +4,32 @@
   (:import (java.util.function Supplier Consumer Function BiFunction)))
 
 (deftest supplier
-  (let [f (sam* Supplier (fn [] "supplied"))]
+  (let [^Supplier f (sam* Supplier (fn [] "supplied"))]
     (is (= "supplied" (.get f)))))
 
 (deftest consumer
   (let [p (promise)
-        f (sam* Consumer (fn [x] (deliver p x)))]
+        ^Consumer f (sam* Consumer (fn [x] (deliver p x)))]
     (is (nil? (.accept f 123)))
     (is (= 123 @p))))
 
 (deftest function
-  (let [f (sam* Function (fn [x] (* x 2)))]
+  (let [^Function f (sam* Function (fn [x] (* x 2)))]
     (is (= 4 (.apply f 2)))))
 
 (deftest bifunction
-  (let [f (sam* BiFunction (fn [x y] (* x y)))]
+  (let [^BiFunction f (sam* BiFunction (fn [x y] (* x y)))]
     (is (= 6 (.apply f 2 3)))))
 
-
 (deftest sam-macro-supplier
-  (let [f (sam Supplier [] "supplied")]
+  (let [^Supplier f (sam Supplier [] "supplied")]
     (is (= "supplied" (.get f)))))
 
 (deftest defsam-macro-supplier
-  (defsam f Supplier [] "supplied")
-  (is (= "supplied" (.get f))))
+  (defsam f1 Supplier [] "supplied")
+  (is (= "supplied" (.get ^Supplier f1))))
 
 (deftest defsam-docstring-macro-supplier
-  (defsam f "It worked!" Supplier [] "supplied")
-  (is (= "supplied" (.get f)))
-  (is (= "It worked!" (:doc (meta #'f)))))
+  (defsam f2 "It worked!" Supplier [] "supplied")
+  (is (= "supplied" (.get ^Supplier f2)))
+  (is (= "It worked!" (:doc (meta #'f2)))))

--- a/src/test/clojure/ike/cljj/stream_test.clj
+++ b/src/test/clojure/ike/cljj/stream_test.clj
@@ -2,34 +2,39 @@
   (:require [clojure.test :refer :all]
             [ike.cljj.stream :refer :all]
             [ike.cljj.function :refer [sam*]])
-  (:import (java.util.stream IntStream)
-           (java.util.function IntPredicate IntUnaryOperator)))
+  (:import [java.util ArrayList]
+           [java.util.function Predicate UnaryOperator]))
+
+(defn range-stream [from to]
+  (-> (range from to)
+      (ArrayList.)
+      (.stream)))
 
 (deftest stream-reduce
-  (let [stream (IntStream/range 0 10)]
+  (let [stream (range-stream 0 10)]
     (is (= 45 (reduce + stream)))))
 
 (deftest stream-into
-  (let [stream (IntStream/range 0 5)]
+  (let [stream (range-stream 0 5)]
     (is (= [0 1 2 3 4] (into [] stream)))))
 
 (deftest stream-transduce
-  (let [stream (IntStream/range 0 10)]
+  (let [stream (range-stream 0 10)]
     (is (= 25 (transduce (filter odd?) + stream)))))
 
 (deftest stream-sequence
-  (let [stream (IntStream/range 0 10)
+  (let [stream (range-stream 0 10)
         sseq (sequence (filter odd?) (stream-seq stream))]
     (is (seq? sseq))
     (is (= '(1 3 5 7 9) sseq))))
 
 (deftest stream-eduction
-  (let [stream (IntStream/range 0 10)
+  (let [stream (range-stream 0 10)
         educ (eduction (filter odd?) (stream-seq stream))]
     (is (= 25 (reduce + 0 educ)))))
 
 (deftest stream-prefiltered-into
-  (let [stream (-> (IntStream/range 0 10)
-                   (.filter (sam* IntPredicate even?))
-                   (.map (sam* IntUnaryOperator (fn [x] (int (* x 3))))))]
+  (let [stream (-> (range-stream 0 10)
+                   (.filter (sam* Predicate even?))
+                   (.map (sam* UnaryOperator (fn [x] (int (* x 3))))))]
     (is (= [0 6 12 18 24] (into [] stream)))))


### PR DESCRIPTION
Reflection (and Java 9, in general) caused some weird errors with ike.cljj, so did the following:

- Added a bunch of type hints to reduce reflection
- Ensured method handle lookups happened within the Clojure runtime and not from `Object`